### PR TITLE
docs: add descriptors for the cookiecutter fields

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,7 @@
   "author": "",
   "__prompts__": {
     "plugin_name": "The project title",
-    "project_slug": "Is used for example for a GitHub repository name",
+    "project_slug": "The name of your Python package",
     "plugin_namespace": "The namespace for your plugin, e.g. `pc`",
     "author": ""
   }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,12 @@
 {
   "plugin_name": "Polars Cookiecutter",
   "project_slug": "{{ cookiecutter.plugin_name.lower().replace(' ', '_').replace('-', '_') }}",
-  "plugin_namespace": "pc",
-  "author": "anonymous"
+  "plugin_namespace": "",
+  "author": "",
+  "__prompts__": {
+    "plugin_name": "The project title",
+    "project_slug": "Is used for example for a GitHub repository name",
+    "plugin_namespace": "The namespace for your plugin, e.g. `pc`",
+    "author": ""
+  }
 }


### PR DESCRIPTION
uses `__prompts__` to add descriptors for the template's field. [ref](https://cookiecutter.readthedocs.io/en/2.5.0/advanced/human_readable_prompts.html#human-readable-prompts)