### PR TITLE
Adds return_scalar to register_plugin

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/utils.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/utils.py
@@ -57,6 +57,7 @@ def register_plugin(
     kwargs: dict[str, Any] | None = None,
     args: list[IntoExpr],
     lib: str | Path,
+    returns_scalar: bool,
 ) -> pl.Expr:
     if parse_version(pl.__version__) < parse_version("0.20.16"):
         assert isinstance(args[0], pl.Expr)
@@ -67,6 +68,7 @@ def register_plugin(
             args=args[1:],
             kwargs=kwargs,
             is_elementwise=is_elementwise,
+            returns_scalar=returns_scalar,
         )
     from polars.plugins import register_plugin_function
 
@@ -76,6 +78,7 @@ def register_plugin(
         function_name=symbol,
         kwargs=kwargs,
         is_elementwise=is_elementwise,
+        returns_scalar=returns_scalar,
     )
 
 def parse_version(version: Sequence[str | int]) -> tuple[int, ...]:


### PR DESCRIPTION
While following https://marcogorelli.github.io/polars-plugins-tutorial/aggregate/#hello-python-my-old-friend, `return_scalar` needs to be passed through for the tutorial to work.