### PR TITLE
Bump v0.41.2 -> v0.41.3

### DIFF
--- a/{{ cookiecutter.project_slug }}/Cargo.toml
+++ b/{{ cookiecutter.project_slug }}/Cargo.toml
@@ -11,7 +11,7 @@ crate-type= ["cdylib"]
 pyo3 = { version = "0.21.2", features = ["extension-module", "abi3-py38"] }
 pyo3-polars = { version = "0.15.0", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
-polars = { version = "0.41.2", default-features = false }
+polars = { version = "0.41.3", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }


### PR DESCRIPTION
This bump fixes an issue in which `polars-lazy` does not match the required version after adding `features=["dtype-struct"]` ([chapter 10](https://marcogorelli.github.io/polars-plugins-tutorial/struct/#10-structin))