### PR TITLE
Add `mypy.ini`

### DIFF
--- a/{{ cookiecutter.project_slug }}/mypy.ini
+++ b/{{ cookiecutter.project_slug }}/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+[mypy-polars.utils.udfs]
+ignore_missing_imports = true


### PR DESCRIPTION
This PR fixes the following mypy error that happens when the available Polars version doesn't have `polars.utils.udfs`.

```
test/__init__.py:16: error: Cannot find implementation or library stub for module named "polars.utils.udfs"  [import-not-found]
test/__init__.py:16: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 5 source files)
```