### PR TITLE
Add `tool.mypy.overrides` to `pyproject.toml`

### DIFF
--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -14,3 +14,6 @@ classifiers = [
 [tool.maturin]
 module-name = "{{ cookiecutter.project_slug }}._internal"
 
+[[tool.mypy.overrides]]
+module = "polars.utils.udfs"
+ignore_missing_imports = true


### PR DESCRIPTION
This PR is an alternative to https://github.com/MarcoGorelli/cookiecutter-polars-plugins/pull/11. I Personally prefer this option to avoid cluttering the project directory.

Fixes the mypy error below, that happens when the available Polars version doesn't have `polars.utils.udfs`.

```
test/__init__.py:16: error: Cannot find implementation or library stub for module named "polars.utils.udfs"  [import-not-found]
test/__init__.py:16: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 5 source files)
```