### PR TITLE
adding two rustup commands that failed when using this cookiecutter

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/publish_to_pypi.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/publish_to_pypi.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Set up Rust
         run: rustup show
+      - run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
+      - run: rustup component add --toolchain nightly-2025-05-21-x86_64-unknown-linux-gnu clippy
       - uses: mozilla-actions/sccache-action@v0.0.6
       - run: make venv
       - run: make pre-commit


### PR DESCRIPTION
I fixed the following build errors in my project with these changes.

https://github.com/paddymul/pl_series_hash/actions/runs/18198368976/job/51810572882
https://github.com/paddymul/pl_series_hash/actions/runs/18198265244/job/51810201259

I'm not sure if this is the correct approach, but I figured I'd share it.
