### PR TITLE
Fix rustup in linux test steps in CI (duplicate of #32)

### DIFF
--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -13,7 +13,7 @@ install-release:
 	source .venv/bin/activate && maturin develop --release
 
 pre-commit:
-	cargo +nightly fmt --all && cargo clippy --all-features
+	cargo fmt --all && cargo clippy --all-features
 	.venv/bin/python -m ruff check . --fix --exit-non-zero-on-fix
 	.venv/bin/python -m ruff format {{ cookiecutter.project_slug }} tests
 	.venv/bin/mypy {{ cookiecutter.project_slug }} tests

--- a/{{ cookiecutter.project_slug }}/rust-toolchain.toml
+++ b/{{ cookiecutter.project_slug }}/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2025-05-21"
-
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
I had the same issue as https://github.com/MarcoGorelli/cookiecutter-polars-plugins/pull/32 and fixed it before I saw that PR. 

This should achieve the same result, but without specifying the nightly version in the workflow .yml (which I think would necessitate keeping it up-to-date with rust-toolchain.toml).